### PR TITLE
Ajuste comandos ReadCells y Find 34.37.25

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2594,6 +2594,13 @@ def get_filtered_cells(sheet, range_, result, extends, excel, xls, wb):
             cell_values = cell_values + \
                 range_cell if len(cell_values) > 0 else range_cell
 
+def excel_column_index_to_string(col_idx):
+    """Convierte un índice de columna numérico a una letra de columna de Excel."""
+    col_str = ''
+    while col_idx > 0:
+        col_idx, rem = divmod(col_idx - 1, 26)
+        col_str = chr(ord('A') + rem) + col_str
+    return col_str
 
 if module == "GetCountCells":
     sheet_ = GetParams("sheet")
@@ -2806,10 +2813,17 @@ if module == "find":
             match_case = False
         else:
             match_case = eval(match_case)
+        if not range_ or range_ =="":
+            #armo rango segun la hoja
+            range1 = sheet_selected.used_range.last_cell.row
+            range2 = sheet_selected.used_range.last_cell.column
+            range_ = f"A1:" + excel_column_index_to_string(range2) + str(range1)
+          
         
         if platform.system() == "Windows":        
             if find_all and eval(find_all):
                 matches = []
+                                
                 range_obj = sheet_selected.api.Range(range_)
                 result = range_obj.Find(What=text, LookAt = look_at, LookIn = look_in, SearchDirection = 1, MatchCase = match_case)
                 try:

--- a/__init__.py
+++ b/__init__.py
@@ -2606,15 +2606,7 @@ def get_filtered_cells(sheet, range_, result, extends, excel, xls, wb):
         else:
             cell_values = cell_values + \
                 range_cell if len(cell_values) > 0 else range_cell
-
-def excel_column_index_to_string(col_idx):
-    """Convierte un índice de columna numérico a una letra de columna de Excel."""
-    col_str = ''
-    while col_idx > 0:
-        col_idx, rem = divmod(col_idx - 1, 26)
-        col_str = chr(ord('A') + rem) + col_str
-    return col_str
-
+            
 if module == "GetCountCells":
     sheet_ = GetParams("sheet")
     range_ = GetParams("range")
@@ -2801,7 +2793,7 @@ if module == "find":
     match_case = GetParams("match_case")
     find_all = GetParams("find_all")
     var_ = GetParams("var_")
-
+    from openpyxl.utils.cell import get_column_letter
     try:
         wb_sheets = [sh.name for sh in wb.sheets]
         sheet=None
@@ -2830,8 +2822,8 @@ if module == "find":
             #armo rango segun la hoja
             range1 = sheet_selected.used_range.last_cell.row
             range2 = sheet_selected.used_range.last_cell.column
-            range_ = f"A1:" + excel_column_index_to_string(range2) + str(range1)
-          
+            range_ = f"A1:" + get_column_letter(range2) + str(range1)
+ 
         
         if platform.system() == "Windows":        
             if find_all and eval(find_all):

--- a/__init__.py
+++ b/__init__.py
@@ -188,6 +188,8 @@ if module == "ReadCells":
     date_format = GetParams("date_format")
     custom = GetParams("custom")
 
+    from datetime import datetime
+
     try:
         if not sheet_:
             sheet = wb.sheets.active
@@ -216,7 +218,6 @@ if module == "ReadCells":
 
         global _values    
         _values = sheet.api.Range(range_).Value2
-        print(_values)
         value = None
         if date_format is not None:
             valueGotten = xw.sheets[sheet].range(range_).value
@@ -229,12 +230,24 @@ if module == "ReadCells":
                 cont = 1
             if (cont > 1):
                 for each in valueGotten:
-                    value_date = each.strftime(date_format)
-                    info.append(value_date)
+                    if isinstance(each, list) or isinstance(each, tuple):
+                        list_ = []
+                        for e in each:
+                            if isinstance(e, datetime):
+                                e = e.strftime(date_format)
+                            list_.append(e)
+                        info.append(list_)
+                        
+                    else:   
+                        if isinstance(each, datetime):
+                            print(each)
+                            each = each.strftime(date_format)
+                        info.append(each)
             else:
-                valueGotten = valueGotten.strftime(date_format)
-                info.append(valueGotten)
-            print(info)
+                if isinstance(each, datetime):
+                    each = valueGotten.strftime(date_format)
+                info.append(each)
+
             SetVar(var_, info)
             
         if date_format is None:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "pr": "Aplique filtros automáticos e avançados, formate células, adicione ou exclua planilhas, linhas ou colunas, exporte para diferentes formatos de arquivo, desbloqueie e bloqueie novamente planilhas, copie e cole especiais e muito mais com seus arquivos do Excel."
   },
   "disclaimer": "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM “AS IS” WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.",
-  "version": "34.37.24",
+  "version": "34.37.25",
   "license": "MIT",
   "homepage": "http://rocketbot.com/",
   "linux": false,
@@ -6830,9 +6830,9 @@
               "pr": "Intervalo onde buscar: "
             },
             "help": {
-              "es": "No usar cabeceras",
-              "en": "Not headers",
-              "pr": "Não usar cabeçeras"
+              "es": "No usar cabeceras, si se deja en blanco buscará sobre toda la hoja",
+              "en": "Not headers, if left blank, the search will be performed on the entire sheet",
+              "pr": "Não usar cabeçeras, se deixado em branco, a busca será realizada em toda a planilha"
             },
             "description": {
               "es": "Celda o Rango de celdas. La sintaxis debe ser la misma de excel (A1 o A1:B1) ",


### PR DESCRIPTION
Add:
- ReadCells: A corrective action was applied because the 'ReadCells' command was not considering ranges with multiple rows and columns. Additionally, it was not evaluating whether the data was of a date type before applying formatting.

- Find: Changes were made to the 'Find' module so that if the range field is left blank, the entire sheet is taken as the search range.